### PR TITLE
Use requests, Python 2/3 compat

### DIFF
--- a/class-materials/py-noaa-template.py
+++ b/class-materials/py-noaa-template.py
@@ -1,8 +1,9 @@
 #!/usr/bin/python
 
 import gzip
+import io
 import pandas as pd
-import urllib
+import requests
 import re
 from IPython.display import display
 
@@ -10,21 +11,20 @@ baseurl = 'http://www1.ncdc.noaa.gov/pub/data/swdi/stormevents/csvfiles/'   #URL
 
 fintable = pd.DataFrame()   #Creating an empty dataframe. Tables will be appended to this dataframe as they are opened.
 
-html = urllib.request.urlopen(baseurl)     #Return the html from main directory page as an HTTP Response object
+html = requests.get(baseurl).text     #Return the html from main directory page as a string
 
-for i in html.readlines():  #Iterating through returned HTTPResponse object, one line at a time.
-    line = i.decode('utf-8').lstrip()   # each line is a byte object, we want a string with no leading whitespace
+for line in html.splitlines():  #Iterating through returned HTTPResponse object, one line at a time.
+    line = line.lstrip()   # we want a string with no leading whitespace
     filename = re.findall(r'StormEvents_details-ftp_v1\.0_d\d{4}_c\d{8}\.csv\.gz', line) #match reg expression pattern and return matches as a list of strings
-    if filename:                 #If the given line contains the match (i.e. returns True), execute the following
+    if filename:                 #If there are matches in this line, execute the following
         yearurl = baseurl + filename[0]      #Add the matched pattern to the base URL to create path to sub table.
-        yearfilezip = urllib.request.urlopen(yearurl)     #Read the gzip table file as an HTTP Response object
-        yearfile = gzip.open(yearfilezip)                 #Read the HTTP Response object using gzip library, returning a file object
-        table = pd.read_csv(yearfile, encoding='ISO-8859-1', low_memory=False)  #Read any unzipped table encoded in UTF-8 as a dataframe
+        yeardatagzip = requests.get(yearurl).content     #Get the table file
+        yearfilegzip = io.BytesIO(yeardatagzip)
+        yearfile = gzip.GzipFile(fileobj=yearfilegzip, mode='rb')
+        table = pd.read_csv(yearfile, low_memory=False)  #Read the table as a dataframe
         fintable = pd.concat([fintable, table])    #Append the dataframe to the final dataframe
 
 #Display an abbreviated version of the table in the Notebook
 display(fintable)
-#Export a select few columns of the dataframe to a csv and save to desktop.
+#Export a select few columns of the dataframe to a csv
 fintable.to_csv(r'PATH TO FILE/storm-events2.csv', encoding='utf-8', columns=["BEGIN_YEARMONTH", "EVENT_ID", "STATE", "STATE_FIPS", "CZ_FIPS", "CZ_NAME", "EVENT_TYPE", "DAMAGE_PROPERTY", "BEGIN_LAT", "BEGIN_LON"])
-
-

--- a/class-materials/txt-crawl-clean.py
+++ b/class-materials/txt-crawl-clean.py
@@ -1,10 +1,8 @@
 #import the right Python libraries to complete our requests
 #the library to grab URLs and data from webpages
-import urllib.request
+import requests
 
 #reads in the URL we want to scrape from
-for line in urllib.request.urlopen('http://bit.ly/2dfjvCC'): 
-    # takes away the B at the beginning of each line (b stands for byte!)
-    cleanLine = line.decode() 
+for line in requests.get('http://bit.ly/2dfjvCC').text.splitlines():
     #strips away white space from the beginning and end of a string -- can strip out other things if we want
-    print (cleanLine.strip()) 
+    print(line.strip())

--- a/class-materials/txt-crawl-csv-export.py
+++ b/class-materials/txt-crawl-csv-export.py
@@ -1,16 +1,19 @@
 #import the right Python libraries to complete our requests
+import io
 #the library to grab URLs and data from webpages
-import urllib.request
+import requests
 #the library that lets us write and read CSVs
 import csv
 
 #put the text file into an array
-lines = urllib.request.urlopen('http://bit.ly/2dfjvCC').read().decode().splitlines()
+lines = requests.get('http://bit.ly/2dfjvCC').text.splitlines()
 
 #this is where we declare where we want to write our file to
-output_file = open('PATH TO FILE/news1.csv', 'w', newline='')
+output_file = open('PATH TO FILE/news1.csv', 'wb')
+#On Python 3, use:
+#output_file = open('PATH TO FILE/news1.csv', 'w', newline='')
 
-#this creates our writer, which will do all our heavy lifting. We give it the name of the output file & the dialect, meaning 
+#this creates our writer, which will do all our heavy lifting. We give it the name of the output file & the dialect, meaning this will create a file readable by Excel
 writer = csv.writer(output_file, dialect='excel')
 
 #I want to add headers to the CSV, since there aren't any in our txt file
@@ -26,12 +29,14 @@ while True:
         row = []
         #put five lines into the row array
         for _ in range(5):
-            row.append(next(line_iterator))
+            item = next(line_iterator)
+            item = item.encode('utf-8') #convert to utf-8 for the output
+            row.append(item)
         #write those five lines across a row
         writer.writerow(row)
         #iterate over the two blank lines in our text file
         next(line_iterator)
         next(line_iterator)
-    #stop the interation when there is nothing left! 
+    #stop the interation when there is nothing left!
     except StopIteration:
         break


### PR DESCRIPTION
- Fixes py-noaa script (though GZIP manipulation might be hard to explain to students)
- Use `requests` instead of urllib, which is much more sane, and allows for Python 2 & 3 compatibility
- Makes code Python 2 & 3 compatible where possible (as far as I understand, txt-crawl-\* scripts were Python 2, py-noaa was Python 3?)

Only incompatibility is opening mode on output CSV in `txt-crawl-csv-export.py`, which I clearly marked.

Good luck for the class! (Or did I miss it? 😨)
